### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "laravel/socialite": "^v5.5.1",
         "socialiteproviders/facebook": "^4.1.0",
         "spatie/laravel-package-tools": "^1.9.2",


### PR DESCRIPTION
Adds `^13.0` to illuminate/* package constraints to support Laravel 13.